### PR TITLE
Fix for issue #75

### DIFF
--- a/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
@@ -128,7 +128,7 @@
       ; &lt;label for="XPoll.XPollClass_0_name"&gt;$doc.displayPrettyName('name', false, false)&lt;/label&gt;
       : #displayPollTitle()
     #end
-    (% class="row" %)
+    (% class="row inline-input-row" %)
     (((
     (% class="col-xs-12 col-sm-4" %)
       (((
@@ -483,6 +483,27 @@
 
 .count {
   color: $theme.textSecondaryColor;
+}
+@media (min-width: 768px) {
+  .inline-input-row>.col-sm-4>dl {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+
+  .inline-input-row>.col-sm-4 {
+    float: none;
+    height: 100%;
+    display: table-cell;
+    vertical-align: top;
+    padding-bottom: 1em;
+  }
+
+  .inline-input-row {
+    height: 100%;
+    display: table;
+  }
 }</code>
     </property>
     <property>


### PR DESCRIPTION
Managed to make the three fields be displayed as @lucaa described in the issue.

![image](https://user-images.githubusercontent.com/45433221/135094764-bbb359af-d70d-4c6e-8a98-9014fac496e5.png)

As she said, the field with the shortest hint has the widest space. Personally, I think it looks ok.

Open to opinions.