### PR TITLE
Fixed the code coverage problem and issue #84

### DIFF
--- a/application-xpoll-api/pom.xml
+++ b/application-xpoll-api/pom.xml
@@ -30,6 +30,9 @@
   <packaging>jar</packaging>
   <name>XPoll Application (Pro) API</name>
   <description>Provides the Java APIs needed by the XPoll Application.</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>0.77</xwiki.jacoco.instructionRatio>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/application-xpoll-api/pom.xml
+++ b/application-xpoll-api/pom.xml
@@ -32,6 +32,7 @@
   <description>Provides the Java APIs needed by the XPoll Application.</description>
   <properties>
     <xwiki.jacoco.instructionRatio>0.77</xwiki.jacoco.instructionRatio>
+    <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
   </properties>
   <dependencies>
     <dependency>

--- a/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/CondorcetPollResultsCalculator.java
+++ b/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/CondorcetPollResultsCalculator.java
@@ -125,9 +125,9 @@ public class CondorcetPollResultsCalculator extends AbstractPollResultsCalculato
     private void computeProposalWeights(List<BaseObject> xpollVotes, Map<String, Map<String, Integer>> ballotsMatrix,
         List<String> proposals)
     {
-        List<String> notVotedProposals = new ArrayList<>(proposals);
 
         for (BaseObject xpollVote : xpollVotes) {
+            List<String> notVotedProposals = new ArrayList<>(proposals);
             List<String> currentVotes = xpollVote.getListValue(DefaultXPollManager.VOTES);
 
             notVotedProposals.removeAll(currentVotes);
@@ -143,8 +143,6 @@ public class CondorcetPollResultsCalculator extends AbstractPollResultsCalculato
                     line.put(notVotedProposal, value + 1);
                 }
             }
-            notVotedProposals.clear();
-            notVotedProposals.addAll(proposals);
         }
     }
 }

--- a/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/CondorcetPollResultsCalculator.java
+++ b/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/CondorcetPollResultsCalculator.java
@@ -143,6 +143,7 @@ public class CondorcetPollResultsCalculator extends AbstractPollResultsCalculato
                     line.put(notVotedProposal, value + 1);
                 }
             }
+            notVotedProposals.clear();
             notVotedProposals.addAll(proposals);
         }
     }

--- a/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/DefaultXPollManager.java
+++ b/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/DefaultXPollManager.java
@@ -80,7 +80,7 @@ public class DefaultXPollManager implements XPollManager
     private Provider<XWikiContext> contextProvider;
 
     @Inject
-    @Named("compactwiki")
+    @Named("local")
     private EntityReferenceSerializer<String> serializer;
 
     @Inject

--- a/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/DefaultXPollManager.java
+++ b/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/DefaultXPollManager.java
@@ -80,7 +80,7 @@ public class DefaultXPollManager implements XPollManager
     private Provider<XWikiContext> contextProvider;
 
     @Inject
-    @Named("local")
+    @Named("compactwiki")
     private EntityReferenceSerializer<String> serializer;
 
     @Inject
@@ -151,7 +151,7 @@ public class DefaultXPollManager implements XPollManager
     private void setUserVotes(List<String> votedProposals, XWikiContext context, XWikiDocument doc,
         DocumentReference user) throws XWikiException
     {
-        String currentUserName = serializer.serialize(user, doc.getDocumentReference().getWikiReference().getName());
+        String currentUserName = serializer.serialize(user, doc.getDocumentReference().getWikiReference());
         BaseObject xpollVoteOfCurrentUser = doc.getXObject(XPOLL_VOTES_CLASS_REFERENCE, USER,
             currentUserName, false);
 

--- a/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/rest/DefaultXPollResource.java
+++ b/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/rest/DefaultXPollResource.java
@@ -58,7 +58,7 @@ public class DefaultXPollResource extends ModifiablePageResource implements XPol
     private XPollManager xPollManager;
 
     @Inject
-    @Named("compactwiki")
+    @Named("local")
     private EntityReferenceSerializer<String> serializer;
 
     @Inject
@@ -67,7 +67,7 @@ public class DefaultXPollResource extends ModifiablePageResource implements XPol
     @Override
     public Response saveXPollAnswers(String wikiName, String spaces, String pageName) throws XWikiRestException
     {
-        if (!contextualAuthorizationManager.hasAccess(Right.EDIT)) {
+        if (!contextualAuthorizationManager.hasAccess(Right.EDIT, getXWikiContext().getUserReference())) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
         XWikiContext context = getXWikiContext();

--- a/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/rest/DefaultXPollResource.java
+++ b/application-xpoll-api/src/main/java/com/xwiki/xpoll/internal/rest/DefaultXPollResource.java
@@ -58,7 +58,7 @@ public class DefaultXPollResource extends ModifiablePageResource implements XPol
     private XPollManager xPollManager;
 
     @Inject
-    @Named("local")
+    @Named("compactwiki")
     private EntityReferenceSerializer<String> serializer;
 
     @Inject
@@ -67,7 +67,9 @@ public class DefaultXPollResource extends ModifiablePageResource implements XPol
     @Override
     public Response saveXPollAnswers(String wikiName, String spaces, String pageName) throws XWikiRestException
     {
-        if (!contextualAuthorizationManager.hasAccess(Right.EDIT, getXWikiContext().getUserReference())) {
+        DocumentReference documentReference = new DocumentReference(pageName, getSpaceReference(spaces, wikiName));
+
+        if (!contextualAuthorizationManager.hasAccess(Right.EDIT, documentReference)) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
         XWikiContext context = getXWikiContext();
@@ -76,7 +78,6 @@ public class DefaultXPollResource extends ModifiablePageResource implements XPol
         // That's why we need to use this workaround: manually getting the POST params in the request object.
         XWikiRequest request = context.getRequest();
         try {
-            DocumentReference documentReference = new DocumentReference(pageName, getSpaceReference(spaces, wikiName));
             DocumentReference userReference = context.getUserReference();
             String userIdentifier = this.serializer.serialize(userReference, new WikiReference(wikiName));
             String[] proposalsArray = request.getParameterValues(userIdentifier);

--- a/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/DefaultPollResultsCalculatorTest.java
+++ b/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/DefaultPollResultsCalculatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.xpoll.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import com.xpn.xwiki.objects.BaseObject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DefaultXPollManager}.
+ *
+ * @version $Id$
+ * @since 2.1
+ */
+@ComponentTest
+public class DefaultPollResultsCalculatorTest
+{
+    @InjectMockComponents
+    private DefaultPollResultsCalculator calculator;
+
+    private final String proposal1 = "Proposal1";
+
+    private final String proposal2 = "Proposal2";
+
+    private final String proposal3 = "Proposal3";
+
+    @Test
+    void calculateResultsTest()
+    {
+
+        BaseObject ballot1 = mock(BaseObject.class);
+        BaseObject ballot2 = mock(BaseObject.class);
+        BaseObject ballot3 = mock(BaseObject.class);
+        BaseObject ballot4 = mock(BaseObject.class);
+
+        when(ballot1.getListValue(DefaultXPollManager.VOTES))
+            .thenReturn(Collections.singletonList(proposal1));
+        when(ballot2.getListValue(DefaultXPollManager.VOTES))
+            .thenReturn(Collections.singletonList(proposal2));
+        when(ballot3.getListValue(DefaultXPollManager.VOTES))
+            .thenReturn(Collections.singletonList(proposal3));
+        when(ballot4.getListValue(DefaultXPollManager.VOTES))
+            .thenReturn(Collections.singletonList(proposal1));
+
+        Map<String, Integer> results = calculator
+            .calculateResults(Arrays.asList(ballot1, ballot2, ballot3, ballot4),
+                Arrays.asList(proposal1, proposal2, proposal3));
+
+        assertEquals(2, results.get(proposal1));
+        assertEquals(1, results.get(proposal2));
+        assertEquals(1, results.get(proposal3));
+    }
+
+    @Test
+    void calculateResultsWithNoVotesTest()
+    {
+        Map<String, Integer> results =
+            calculator.calculateResults(Collections.emptyList(), Arrays.asList(proposal1, proposal2, proposal3));
+
+        assertEquals(0, results.get(proposal1));
+        assertEquals(0, results.get(proposal2));
+        assertEquals(0, results.get(proposal3));
+    }
+
+    @Test
+    void calculateResultsWithNoProposalsTest()
+    {
+        Map<String, Integer> results =
+            calculator.calculateResults(Collections.emptyList(), Collections.emptyList());
+        assertEquals(0, results.size());
+    }
+}

--- a/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/UpdatePollWinnersListenerTest.java
+++ b/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/UpdatePollWinnersListenerTest.java
@@ -91,7 +91,6 @@ public class UpdatePollWinnersListenerTest
 
         this.listener.onEvent(new DocumentUpdatedEvent(), this.document, this.xWikiContext);
 
-
         verify(this.xpollObject).set("winner", "Proposal1", xWikiContext);
         verify(this.wiki).saveDocument(this.document, "Updated winner", this.xWikiContext);
     }

--- a/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/rest/DefaultXPollResourceTest.java
+++ b/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/rest/DefaultXPollResourceTest.java
@@ -73,7 +73,6 @@ public class DefaultXPollResourceTest
     private MockitoComponentManager componentManager;
 
     @MockComponent
-    @Named("compactwiki")
     private EntityReferenceSerializer<String> serializer;
 
     @MockComponent
@@ -104,8 +103,7 @@ public class DefaultXPollResourceTest
     @Test
     void saveXPollAnswersTest() throws XWikiRestException, XPollException
     {
-        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT)).thenReturn(true);
-        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT, null)).thenReturn(true);
         when(this.xWikiContext.getRequest()).thenReturn(this.request);
 
         when(this.serializer.serialize(null, new WikiReference("wiki"))).thenReturn("userIdentifier");
@@ -128,8 +126,7 @@ public class DefaultXPollResourceTest
     @Test
     void saveXPollAnswersWithoutEditRightTest2() throws XPollException, XWikiRestException
     {
-        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT)).thenReturn(true);
-        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT, null)).thenReturn(true);
         when(this.xWikiContext.getRequest()).thenReturn(this.request);
         when(this.serializer.serialize(null, new WikiReference("wiki"))).thenReturn("userIdentifier");
 

--- a/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/rest/DefaultXPollResourceTest.java
+++ b/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/rest/DefaultXPollResourceTest.java
@@ -103,12 +103,12 @@ public class DefaultXPollResourceTest
     @Test
     void saveXPollAnswersTest() throws XWikiRestException, XPollException
     {
-        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT, null)).thenReturn(true);
+        DocumentReference docRef = new DocumentReference("xwiki", "Main", "WebHome");
+        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT, docRef)).thenReturn(true);
         when(this.xWikiContext.getRequest()).thenReturn(this.request);
 
         when(this.serializer.serialize(null, new WikiReference("wiki"))).thenReturn("userIdentifier");
 
-        DocumentReference docRef = new DocumentReference("xwiki", "Main", "WebHome");
         Response response = resource.saveXPollAnswers("xwiki", "Main", "WebHome");
 
         verify(this.xPollManager).vote(docRef, null, Collections.emptyList());
@@ -119,18 +119,18 @@ public class DefaultXPollResourceTest
     void saveXPollAnswersWithoutEditRightTest() throws XWikiRestException
     {
         when(this.contextualAuthorizationManager.hasAccess(Right.EDIT)).thenReturn(false);
-        Response response = this.resource.saveXPollAnswers("", "", "");
+        Response response = this.resource.saveXPollAnswers("wiki", "space", "page");
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
     }
 
     @Test
     void saveXPollAnswersWithoutEditRightTest2() throws XPollException, XWikiRestException
     {
-        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT, null)).thenReturn(true);
+        DocumentReference docRef = new DocumentReference("xwiki", "Main", "WebHome");
+        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT, docRef)).thenReturn(true);
         when(this.xWikiContext.getRequest()).thenReturn(this.request);
         when(this.serializer.serialize(null, new WikiReference("wiki"))).thenReturn("userIdentifier");
 
-        DocumentReference docRef = new DocumentReference("xwiki", "Main", "WebHome");
 
         doThrow(new XPollException("Message")).when(this.xPollManager).vote(docRef, null, Collections.emptyList());
         Response response = resource.saveXPollAnswers("xwiki", "Main", "WebHome");

--- a/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/rest/DefaultXPollResourceTest.java
+++ b/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/rest/DefaultXPollResourceTest.java
@@ -1,0 +1,142 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.xpoll.internal.rest;
+
+import java.util.Collections;
+
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.rest.XWikiRestException;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.web.XWikiRequest;
+import com.xwiki.xpoll.XPollException;
+import com.xwiki.xpoll.XPollManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DefaultXPollResource}.
+ *
+ * @version $Id$
+ * @since 2.1
+ */
+@ComponentTest
+public class DefaultXPollResourceTest
+{
+    @InjectMockComponents
+    private DefaultXPollResource resource;
+
+    @MockComponent
+    private XPollManager xPollManager;
+
+    @InjectComponentManager
+    private MockitoComponentManager componentManager;
+
+    @MockComponent
+    @Named("compactwiki")
+    private EntityReferenceSerializer<String> serializer;
+
+    @MockComponent
+    private ContextualAuthorizationManager contextualAuthorizationManager;
+
+    @MockComponent
+    protected Provider<XWikiContext> xcontextProvider;
+
+    private XWikiContext xWikiContext;
+
+    @Mock
+    private XWikiRequest request;
+
+    @BeforeComponent
+    public void configure() throws Exception
+    {
+        ComponentManager contextComponentManager =
+            this.componentManager.registerMockComponent(ComponentManager.class, "context");
+        Execution execution = mock(Execution.class);
+        when(contextComponentManager.getInstance(Execution.class)).thenReturn(execution);
+        ExecutionContext executionContext = new ExecutionContext();
+        this.xWikiContext = mock(XWikiContext.class);
+        executionContext.setProperty("xwikicontext", this.xWikiContext);
+        when(execution.getContext()).thenReturn(executionContext);
+        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+    }
+
+    @Test
+    void saveXPollAnswersTest() throws XWikiRestException, XPollException
+    {
+        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT)).thenReturn(true);
+        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+        when(this.xWikiContext.getRequest()).thenReturn(this.request);
+
+        when(this.serializer.serialize(null, new WikiReference("wiki"))).thenReturn("userIdentifier");
+
+        DocumentReference docRef = new DocumentReference("xwiki", "Main", "WebHome");
+        Response response = resource.saveXPollAnswers("xwiki", "Main", "WebHome");
+
+        verify(this.xPollManager).vote(docRef, null, Collections.emptyList());
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void saveXPollAnswersWithoutEditRightTest() throws XWikiRestException
+    {
+        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT)).thenReturn(false);
+        Response response = this.resource.saveXPollAnswers("", "", "");
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void saveXPollAnswersWithoutEditRightTest2() throws XPollException, XWikiRestException
+    {
+        when(this.contextualAuthorizationManager.hasAccess(Right.EDIT)).thenReturn(true);
+        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+        when(this.xWikiContext.getRequest()).thenReturn(this.request);
+        when(this.serializer.serialize(null, new WikiReference("wiki"))).thenReturn("userIdentifier");
+
+        DocumentReference docRef = new DocumentReference("xwiki", "Main", "WebHome");
+
+        doThrow(new XPollException("Message")).when(this.xPollManager).vote(docRef, null, Collections.emptyList());
+        Response response = resource.saveXPollAnswers("xwiki", "Main", "WebHome");
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+}

--- a/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/script/XPollScriptServiceTest.java
+++ b/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/script/XPollScriptServiceTest.java
@@ -1,0 +1,81 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.xpoll.internal.script;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xwiki.xpoll.XPollException;
+import com.xwiki.xpoll.XPollManager;
+import com.xwiki.xpoll.internal.DefaultXPollManager;
+import com.xwiki.xpoll.internal.rest.DefaultXPollResource;
+import com.xwiki.xpoll.script.XPollScriptService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link com.xwiki.xpoll.script.XPollScriptService}.
+ *
+ * @version $Id$
+ * @since 2.1
+ */
+@ComponentTest
+public class XPollScriptServiceTest
+{
+    @InjectMockComponents
+    private XPollScriptService scriptService;
+
+    @MockComponent
+    private XPollManager manager;
+
+    @MockComponent
+    private ContextualAuthorizationManager authorizationManager;
+
+    @Test
+    void urlTest() {
+        scriptService.url(null);
+        verify(manager).getRestURL(null);
+    }
+
+    @Test
+    void getVoteResultsWithAuthorizationTest() throws XPollException
+    {
+        when(this.authorizationManager.hasAccess(Right.VIEW)).thenReturn(true);
+        scriptService.getVoteResults(null);
+        verify(this.manager).getVoteResults(null);
+    }
+
+    @Test
+    void getVoteResultsWithAuthorizationAndThrownExceptionTest() throws XPollException
+    {
+        when(this.authorizationManager.hasAccess(Right.VIEW)).thenReturn(true);
+        when(manager.getVoteResults(null)).thenThrow(XPollException.class);
+        Map<String, Integer> result = scriptService.getVoteResults(null);
+        assertEquals(0, result.size());
+    }
+}

--- a/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/script/XPollScriptServiceTest.java
+++ b/application-xpoll-api/src/test/java/com/xwiki/xpoll/internal/script/XPollScriptServiceTest.java
@@ -19,9 +19,12 @@
  */
 package com.xwiki.xpoll.internal.script;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.junit5.mockito.ComponentTest;
@@ -57,25 +60,37 @@ public class XPollScriptServiceTest
     private ContextualAuthorizationManager authorizationManager;
 
     @Test
-    void urlTest() {
-        scriptService.url(null);
-        verify(manager).getRestURL(null);
+    void urlTest()
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "name");
+        String urlResult = "output";
+
+        when(manager.getRestURL(documentReference)).thenReturn(urlResult);
+
+        assertEquals(urlResult, scriptService.url(documentReference));
     }
 
     @Test
     void getVoteResultsWithAuthorizationTest() throws XPollException
     {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "name");
+        Map<String, Integer> results = Collections.emptyMap();
+
         when(this.authorizationManager.hasAccess(Right.VIEW)).thenReturn(true);
-        scriptService.getVoteResults(null);
-        verify(this.manager).getVoteResults(null);
+        when(this.manager.getVoteResults(documentReference)).thenReturn(results);
+
+        assertEquals(results, scriptService.getVoteResults(documentReference));
     }
 
     @Test
     void getVoteResultsWithAuthorizationAndThrownExceptionTest() throws XPollException
     {
+        DocumentReference documentReference = new DocumentReference("wiki", "Space", "name");
+
         when(this.authorizationManager.hasAccess(Right.VIEW)).thenReturn(true);
-        when(manager.getVoteResults(null)).thenThrow(XPollException.class);
-        Map<String, Integer> result = scriptService.getVoteResults(null);
+        when(manager.getVoteResults(documentReference)).thenThrow(XPollException.class);
+
+        Map<String, Integer> result = scriptService.getVoteResults(documentReference);
         assertEquals(0, result.size());
     }
 }

--- a/application-xpoll-ui/src/main/resources/XPoll/Translation.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/Translation.xml
@@ -48,6 +48,7 @@ contrib.xpoll.status.finished=Finished
 contrib.xpoll.status.inPreparation=In preparation
 contrib.xpoll.user=Users
 contrib.xpoll.vote.failed=Failed to save the document. Reason: {0}
+contrib.xpoll.vote.failed.forbidden=Not allowed to vote!
 contrib.xpoll.vote.guest.submit=Save
 contrib.xpoll.vote.user.submit=Save
 contrib.xpoll.vote.saved=Saved

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollJSExtension.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollJSExtension.xml
@@ -149,8 +149,7 @@
         error: function(data) {
           if (data.status == 403) {
             new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed.forbidden')", 'error');
-          }
-          else {
+          } else {
             new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed', 'HTTP Error')", 'error');
           }
         }

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollJSExtension.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollJSExtension.xml
@@ -137,20 +137,16 @@
         beforeSend: function() {
           this.progressNotification = new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.saving')", 'inprogress');
         },
-        complete:function() {
-          // Disable inprogress notification widget.
-          this.progressNotification.hide();
-        },
         success: function(data) {
-          new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.saved')", 'done');
+          this.progressNotification.replace(new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.saved')", 'done'));
           // Reload just the form with the id="xpollSaveForm" which contains the table.
           $('#xpollSaveForm').load(XWiki.currentDocument.getURL('get') +  ' #xpollSaveForm&gt;*');
         },
         error: function(data) {
           if (data.status == 403) {
-            new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed.forbidden')", 'error');
+            this.progressNotification.replace(new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed.forbidden')", 'error'));
           } else {
-            new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed', 'HTTP Error')", 'error');
+            this.progressNotification.replace(new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed', 'HTTP Error')", 'error'));
           }
         }
       });

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollJSExtension.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollJSExtension.xml
@@ -147,7 +147,12 @@
           $('#xpollSaveForm').load(XWiki.currentDocument.getURL('get') +  ' #xpollSaveForm&gt;*');
         },
         error: function(data) {
-          new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed', 'HTTP Error')", 'error');
+          if (data.status == 403) {
+            new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed.forbidden')", 'error');
+          }
+          else {
+            new XWiki.widgets.Notification("$services.localization.render('contrib.xpoll.vote.failed', 'HTTP Error')", 'error');
+          }
         }
       });
     });

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
@@ -241,7 +241,7 @@
   ## This is needed to update the number of user when the status is active and the deleted users are hidden.
   #set ($usersCountActive = 0)
   #foreach ($obj in $doc.getObjects('XPoll.XPollVoteClass'))
-    #if ($xwiki.exists($services.model.resolveDocument($user)) || $xwiki.exists("$xcontext.mainWikiName:$user"))
+    #if ($xwiki.exists($obj.user))
       #set ($usersCountActive = $usersCountActive + 1)
     #end
   #end
@@ -278,23 +278,16 @@
           #set ($foundUser = false)
           #foreach ($voteObj in $doc.getObjects('XPoll.XPollVoteClass'))
             #set ($user = $voteObj.user)
-            #set ($isCurrentUser = $user == $services.model.serialize($services.model.resolveDocument($xcontext.user), 'local'))
+            #set ($isCurrentUser = $user.equals($xcontext.user))
             #set ($votes = $voteObj.getValue('votes'))
             &lt;tr #if($isCurrentUser)class="active"#end&gt;
               #if ($isCurrentUser)
                 #set ($foundUser = true)
               #end
               ## We check if the saved user exists locally in the subwiki or is a global user
-              #set($tmp = $services.model.serialize($services.model.resolveDocument($user)))
-              #set($completeUser = '')
-              #if ($xwiki.exists($tmp))
-                #set ($completeUser = $tmp)
-              #elseif ($xwiki.exists("$xcontext.mainWikiName:$user"))
-                #set ($completeUser = "$xcontext.mainWikiName:$user")
-              #end
-              #if ($completeUser != '')
+              #if ($xwiki.exists($user))
                 &lt;td&gt;
-                  #displayUser($completeUser)
+                  #displayUser($user)
                 &lt;/td&gt;
                 #displayInput($votes $isCurrentUser $user)
               #end
@@ -308,7 +301,7 @@
                 #displayUser($xcontext.user)
               &lt;/td&gt;
               ## The 3rd parameter is true in order to not disable the input for current user.
-              #displayInput([] true $services.model.serialize($services.model.resolveDocument($xcontext.user), 'local'))
+              #displayInput([] true $xcontext.user)
             &lt;/tr&gt;
           #end
           &lt;/tbody&gt;

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
@@ -241,7 +241,7 @@
   ## This is needed to update the number of user when the status is active and the deleted users are hidden.
   #set ($usersCountActive = 0)
   #foreach ($obj in $doc.getObjects('XPoll.XPollVoteClass'))
-    #if ($xwiki.exists($obj.user))
+    #if ($xwiki.exists($services.model.resolveDocument($user)) || $xwiki.exists("$xcontext.mainWikiName:$user"))
       #set ($usersCountActive = $usersCountActive + 1)
     #end
   #end
@@ -278,15 +278,23 @@
           #set ($foundUser = false)
           #foreach ($voteObj in $doc.getObjects('XPoll.XPollVoteClass'))
             #set ($user = $voteObj.user)
-            #set ($isCurrentUser = $user == $xcontext.user)
+            #set ($isCurrentUser = $user == $services.model.serialize($services.model.resolveDocument($xcontext.user), 'local'))
             #set ($votes = $voteObj.getValue('votes'))
             &lt;tr #if($isCurrentUser)class="active"#end&gt;
               #if ($isCurrentUser)
                 #set ($foundUser = true)
               #end
-              #if ($xwiki.exists($user))
+              ## We check if the saved user exists locally in the subwiki or is a global user
+              #set($tmp = $services.model.serialize($services.model.resolveDocument($user)))
+              #set($completeUser = '')
+              #if ($xwiki.exists($tmp))
+                #set ($completeUser = $tmp)
+              #elseif ($xwiki.exists("$xcontext.mainWikiName:$user"))
+                #set ($completeUser = "$xcontext.mainWikiName:$user")
+              #end
+              #if ($completeUser != '')
                 &lt;td&gt;
-                  #displayUser($user)
+                  #displayUser($completeUser)
                 &lt;/td&gt;
                 #displayInput($votes $isCurrentUser $user)
               #end
@@ -300,7 +308,7 @@
                 #displayUser($xcontext.user)
               &lt;/td&gt;
               ## The 3rd parameter is true in order to not disable the input for current user.
-              #displayInput([] true $xcontext.user)
+              #displayInput([] true $services.model.serialize($services.model.resolveDocument($xcontext.user), 'local'))
             &lt;/tr&gt;
           #end
           &lt;/tbody&gt;

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
@@ -284,7 +284,6 @@
               #if ($isCurrentUser)
                 #set ($foundUser = true)
               #end
-              ## We check if the saved user exists locally in the subwiki or is a global user
               #if ($xwiki.exists($user))
                 &lt;td&gt;
                   #displayUser($user)


### PR DESCRIPTION
For the code coverage problems, I created some more unit tests for the API and set the maven `xwiki.jacoco.instructionRatio` property to 0.77 as a starting value.

Issue #84 showcased more than one simple problem. The initial problem was that the API had to be installed on the main wiki for the REST entrypoint to be visible. After getting this out of the way, several issues came out with regards to the voters and the xwikis they belonged to - which manifested in not being able to vote, not displaying properly the number of voters, not displaying the casted votes, not being allowed to vote if you were a local user of a subwiki.