### PR TITLE
When "Vote Privacy" and "Poll Publicity" are both Private, guest users can see the table Header of the poll and the description #126

### DIFF
--- a/application-xpoll-test/application-xpoll-test-docker/src/test/it/com/xwiki/xpoll/test/ui/PollIT.java
+++ b/application-xpoll-test/application-xpoll-test-docker/src/test/it/com/xwiki/xpoll/test/ui/PollIT.java
@@ -90,7 +90,7 @@ class PollIT
 
     private static final String POLL_PUBLICITY_PRIVATE_LABEL = "Private";
 
-    private static final String EMPTY_PAGE_VOTE_WARNING = "No content on this page.";
+    private static final String EMPTY_PAGE_VOTE_WARNING = "You are not allowed to access this content.";
 
     private static final String GUEST_CANNOT_CHANGE_VOTE_WARNING = "Your vote has been recorded. At this point, you "
         + "can no longer change it!" ;
@@ -420,20 +420,9 @@ class PollIT
     @Order(13)
     void createNewEntryAndVoteWithGuestPollPublicityPublic()
     {
-        XPollHomePage xpollHomePage = XPollHomePage.gotoPage();
-        createPage(xpollHomePage);
-        editPage(STATUS_ACTIVE, POLL_VOTE_PRIVACY_PRIVATE_VALUE, POLL_PUBLICITY_PUBLIC_VALUE);
+        createPollAndVoteWithGuestUser(STATUS_ACTIVE, POLL_VOTE_PRIVACY_PRIVATE_VALUE, POLL_PUBLICITY_PUBLIC_VALUE);
 
         ActiveStatusViewPage activeStatusViewPage = new ActiveStatusViewPage();
-        activeStatusViewPage.logout();
-
-        activeStatusViewPage = new ActiveStatusViewPage();
-        assertNotNull(activeStatusViewPage.saveButton);
-
-        activeStatusViewPage.voteSetGuestName("Guest");
-        voteProposals(List.of(1));
-
-        activeStatusViewPage = new ActiveStatusViewPage();
 
         String inputCheckedAttribute = activeStatusViewPage.getVoteInput(1).getAttribute("checked");
 
@@ -459,24 +448,13 @@ class PollIT
     @Order(15)
     void createNewEntryAndVoteWithGuestPollPublicityPublicStatusFinal(TestUtils setup)
     {
-        XPollHomePage xpollHomePage = XPollHomePage.gotoPage();
-        createPage(xpollHomePage);
-        editPage(STATUS_ACTIVE, POLL_VOTE_PRIVACY_PUBLIC_VALUE, POLL_PUBLICITY_PUBLIC_VALUE);
-
-        ActiveStatusViewPage activeStatusViewPage = new ActiveStatusViewPage();
-        activeStatusViewPage.logout();
-
-        activeStatusViewPage = new ActiveStatusViewPage();
-        assertNotNull(activeStatusViewPage.saveButton);
-
-        activeStatusViewPage.voteSetGuestName("Guest");
-        voteProposals(List.of(1));
+        createPollAndVoteWithGuestUser(STATUS_ACTIVE, POLL_VOTE_PRIVACY_PUBLIC_VALUE, POLL_PUBLICITY_PUBLIC_VALUE);
 
         setup.loginAndGotoPage("JaneDoe", "pass", setup.getURL(new LocalDocumentReference(POLL_SPACE, POLL_NAME)));
 
         voteProposals(List.of(1));
 
-        activeStatusViewPage = new ActiveStatusViewPage();
+        ActiveStatusViewPage activeStatusViewPage = new ActiveStatusViewPage();
         activeStatusViewPage.edit();
 
         XPollEditPage xpollEditPage = new XPollEditPage();
@@ -490,33 +468,20 @@ class PollIT
         assertEquals(1, finishedStatusViewPage.getNumberOfUsersThatAlreadyVotedFromTable());
     }
 
+    /**
+     * This test verifies the behavior of the polls when a guest user has already voted, and voting rights for guest
+     * users are revoked. In this scenario, a warning message should be displayed, and the guest user's
+     * vote should appear as a disabled input field.
+     */
     @Test
     @Order(16)
     void createNewEntryAndVoteWithGuestPollPublicityPublicChangePollPublicityPrivate(TestUtils setup)
     {
-        XPollHomePage xpollHomePage = XPollHomePage.gotoPage();
-        createPage(xpollHomePage);
-        editPage(STATUS_ACTIVE, POLL_VOTE_PRIVACY_PRIVATE_VALUE, POLL_PUBLICITY_PUBLIC_VALUE);
-
-        ActiveStatusViewPage activeStatusViewPage = new ActiveStatusViewPage();
-        activeStatusViewPage.logout();
-
-        activeStatusViewPage = new ActiveStatusViewPage();
-        assertNotNull(activeStatusViewPage.saveButton);
-
-        activeStatusViewPage.voteSetGuestName("Guest");
-        voteProposals(List.of(1));
-
-        activeStatusViewPage = new ActiveStatusViewPage();
-
-        String inputCheckedAttribute = activeStatusViewPage.getVoteInput(1).getAttribute("checked");
-
-        assertEquals("true", inputCheckedAttribute);
-        assertEquals("Guest", activeStatusViewPage.voteGetGuestName());
+        createPollAndVoteWithGuestUser(STATUS_ACTIVE, POLL_VOTE_PRIVACY_PRIVATE_VALUE, POLL_PUBLICITY_PUBLIC_VALUE);
 
         setup.loginAndGotoPage("JaneDoe", "pass", setup.getURL(new LocalDocumentReference(POLL_SPACE, POLL_NAME)));
 
-        activeStatusViewPage = new ActiveStatusViewPage();
+        ActiveStatusViewPage activeStatusViewPage = new ActiveStatusViewPage();
         activeStatusViewPage.edit();
 
         XPollEditPage xpollEditPage = new XPollEditPage();
@@ -529,12 +494,26 @@ class PollIT
 
         assertEquals(GUEST_CANNOT_CHANGE_VOTE_WARNING, activeStatusViewPage.getGuestCannotChangeVoteWarningMessage());
 
-        inputCheckedAttribute = activeStatusViewPage.getVoteInput(1).getAttribute("checked");
+        String inputCheckedAttribute = activeStatusViewPage.getVoteInput(1).getAttribute("checked");
         boolean inputIsDisabled = activeStatusViewPage.getVoteInput(1).getAttribute("disabled") != null;
 
         assertEquals("true", inputCheckedAttribute);
         assertEquals("Guest", activeStatusViewPage.voteGetGuestName());
         assertTrue(inputIsDisabled);
+    }
+
+    private void createPollAndVoteWithGuestUser(String status, String votePrivacy, String pollPublicity) {
+        XPollHomePage xpollHomePage = XPollHomePage.gotoPage();
+        createPage(xpollHomePage);
+        editPage(status, votePrivacy, pollPublicity);
+
+        ActiveStatusViewPage activeStatusViewPage = new ActiveStatusViewPage();
+        activeStatusViewPage.logout();
+
+        activeStatusViewPage = new ActiveStatusViewPage();
+
+        activeStatusViewPage.voteSetGuestName("Guest");
+        voteProposals(List.of(1));
     }
 
     private void createPage(XPollHomePage xpollHomePage)

--- a/application-xpoll-test/application-xpoll-test-pageobjects/src/main/java/com/xwiki/xpoll/test/po/ActiveStatusViewPage.java
+++ b/application-xpoll-test/application-xpoll-test-pageobjects/src/main/java/com/xwiki/xpoll/test/po/ActiveStatusViewPage.java
@@ -47,6 +47,12 @@ public class ActiveStatusViewPage extends ViewPage
     @FindBy(xpath = "//table[contains(@class, 'xpoll')]//tbody//tr//a")
     public List<WebElement> usersThatVotedTableRows;
 
+    @FindBy(xpath = "//*[@class='box warningmessage']//p")
+    public WebElement emptyPageWarningMessage;
+
+    @FindBy(xpath = "//*[@class='box warningmessage']")
+    public WebElement guestCannotChangeVoteWarningMessage;
+
     public ArrayList<String> pollProposals = new ArrayList<String>();
 
     public String getDescription()
@@ -83,6 +89,16 @@ public class ActiveStatusViewPage extends ViewPage
 
     public int getNumberOfUsersThatAlreadyVotedFromTable() {
         return usersThatVotedTableRows.size();
+    }
+
+    public String getEmptyPageWarningMessage()
+    {
+        return emptyPageWarningMessage.getText();
+    }
+
+    public String getGuestCannotChangeVoteWarningMessage()
+    {
+        return guestCannotChangeVoteWarningMessage.getText();
     }
 
     public boolean searchIfUserIsInTable(String user) {

--- a/application-xpoll-test/application-xpoll-test-pageobjects/src/main/java/com/xwiki/xpoll/test/po/FinishedStatusViewPage.java
+++ b/application-xpoll-test/application-xpoll-test-pageobjects/src/main/java/com/xwiki/xpoll/test/po/FinishedStatusViewPage.java
@@ -32,7 +32,7 @@ import org.xwiki.test.ui.po.ViewPage;
  */
 public class FinishedStatusViewPage extends ViewPage
 {
-    @FindBy(xpath = "//div[@id = 'xwikicontent']/p[2]")
+    @FindBy(xpath = "//div[@id = 'xwikicontent']/p")
     public WebElement pollDescription;
 
     public List<WebElement> proposals = getDriver().findElements(By.xpath("//table//tr[1]//th[position()>1]"));
@@ -44,6 +44,9 @@ public class FinishedStatusViewPage extends ViewPage
 
     @FindBy(xpath = "//table[contains(@class, 'xpoll')]//tbody//tr//td[1][not(descendant::a) and not(contains(translate(., 'SCORES', 'scores'), 'scores'))]")
     public List<WebElement> guestUsersThatVotedTableRows;
+
+    @FindBy(xpath = "//*[@class='box warningmessage']//p")
+    public WebElement emptyPageWarningMessage;
 
     public String getDescription()
     {
@@ -68,6 +71,11 @@ public class FinishedStatusViewPage extends ViewPage
     public int getNumberOfGuestsThatVotedFromTable()
     {
         return guestUsersThatVotedTableRows.size();
+    }
+
+    public String getEmptyPageWarningMessage()
+    {
+        return emptyPageWarningMessage.getText();
     }
 
     public boolean searchIfGuestUserIsInTable(String user)

--- a/application-xpoll-ui/src/main/resources/XPoll/Translation.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/Translation.xml
@@ -39,7 +39,7 @@
   <content>polls.extension.name=Polls Application (Pro)
 
 contrib.xpoll.app.title=Polls
-contrib.xpoll.emptyPage=No content on this page.
+contrib.xpoll.emptyPage=You are not allowed to access this content.
 contrib.xpoll.finish.message=Vote is finished. Here are the results:
 contrib.xpoll.guestCannotChangeVote=Your vote has been recorded. At this point, you can no longer change it!
 contrib.xpoll.home.title=Polls

--- a/application-xpoll-ui/src/main/resources/XPoll/Translation.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/Translation.xml
@@ -39,7 +39,7 @@
   <content>polls.extension.name=Polls Application (Pro)
 
 contrib.xpoll.app.title=Polls
-contrib.xpoll.emptyPage=You are not allowed to access this content.
+contrib.xpoll.emptyPage=No content on this page.
 contrib.xpoll.finish.message=Vote is finished. Here are the results:
 contrib.xpoll.guestCannotChangeVote=Your vote has been recorded. At this point, you can no longer change it!
 contrib.xpoll.home.title=Polls

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
@@ -274,14 +274,15 @@
   {{/html}}
 #else
   #set ($proposals = $pollObj.getValue('proposals'))
-  #set ($isPollPublicityPublic = $pollPublicity == 'public')
+  #set ($isPollPublicityPublic = $pollPublicity == 'public' || $hasEdit)
+  #set ($usersCountActive = 0)
+  #set ($usersCount = 0)
   ## Check to see if an user can vote.
   #set ($userCanVote = !$isCurrentContextUserGuest || $isPollPublicityPublic)
   #if($displayAllUsers)
     #set ($usersCount = $doc.getObjects('XPoll.XPollVoteClass').size())
     ## Count only the existing users, without the deleted users.
     ## This is needed to update the number of user when the status is active and the deleted users are hidden.
-    #set ($usersCountActive = 0)
     #foreach ($obj in $doc.getObjects('XPoll.XPollVoteClass'))
       #if ($xwiki.exists($obj.user) || (!$obj.guestId.isEmpty()))
         #set ($usersCountActive = $usersCountActive + 1)
@@ -304,155 +305,153 @@
       #set ($currentUserVoted = true)
     #end
   #end
-  #set ($showPollSummary = !$isCurrentContextUserGuest || $currentGuestUserVoted || $userCanVote || ($usersCountActive &gt; 0 &amp;&amp; $displayAllUsers ))
   #if ($status == 'active')
-    #if ($showPollSummary)
-      $doc.display('description')
-    #end
+    #set ($showPollSummary = !$isCurrentContextUserGuest || $currentGuestUserVoted || $userCanVote || ($usersCountActive &gt; 0 &amp;&amp; $displayAllUsers ))
     #set ($restURL = $services.xpoll.url($doc.documentReference))
-    #if (!$isPollPublicityPublic &amp;&amp; $currentGuestUserVoted)
-      {{warning}}
-      $escapetool.xml($services.localization.render('contrib.xpoll.guestCannotChangeVote'))
-      {{/warning}}
-
-    #end
+    {{html clean='false', wiki='true'}}
     #if (!($showPollSummary || $displayAllUsers))
       {{warning}}
       $escapetool.xml($services.localization.render('contrib.xpoll.emptyPage'))
       {{/warning}}
-    #end
-    {{html clean='false'}}
-    &lt;form id="xpollSaveForm" action="$restURL" method="put"&gt;
-      &lt;div id="xpollTableWrapper"&gt;
-        &lt;table class='xpoll medium-avatars table table-bordered'&gt;
-          ## Table header row.
-          #if ($showPollSummary)
-            &lt;thead&gt;
-              &lt;tr&gt;
-                &lt;th&gt;
-                  #if($displayAllUsers)
-                    #if($usersCountActive == 1)
+    #else
+      $doc.display('description')
+      #if (!$isPollPublicityPublic &amp;&amp; $currentGuestUserVoted)
+        {{warning}}
+        $escapetool.xml($services.localization.render('contrib.xpoll.guestCannotChangeVote'))
+        {{/warning}}
+      #end
+      &lt;form id="xpollSaveForm" action="$restURL" method="put"&gt;
+        &lt;div id="xpollTableWrapper"&gt;
+          &lt;table class='xpoll medium-avatars table table-bordered'&gt;
+            ## Table header row.
+            #if ($showPollSummary)
+              &lt;thead&gt;
+                &lt;tr&gt;
+                  &lt;th&gt;
+                    #if($displayAllUsers)
+                      #if($usersCountActive == 1)
+                        $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
+                      #else
+                        $escapetool.xml($services.localization.render('contrib.xpoll.user'))
+                        &lt;span class='count'&gt;($usersCountActive)&lt;/span&gt;
+                      #end
+                    #elseif ($currentGuestUserVoted || $currentUserVoted)
                       $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
                     #else
                       $escapetool.xml($services.localization.render('contrib.xpoll.user'))
-                      &lt;span class='count'&gt;($usersCountActive)&lt;/span&gt;
+                      &lt;span class='count'&gt;(0)&lt;/span&gt;
                     #end
-                  #elseif ($currentGuestUserVoted || $currentUserVoted)
-                    $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
-                  #else
-                    $escapetool.xml($services.localization.render('contrib.xpoll.user'))
-                    &lt;span class='count'&gt;(0)&lt;/span&gt;
-                  #end
-                &lt;/th&gt;
-                #foreach($proposal in $proposals)
-                  &lt;th&gt;
-                    &lt;label for="xpoll-proposal$proposal.hashCode()"&gt;
-                      $proposal
-                    &lt;/label&gt;
                   &lt;/th&gt;
+                  #foreach($proposal in $proposals)
+                    &lt;th&gt;
+                      &lt;label for="xpoll-proposal$proposal.hashCode()"&gt;
+                        $proposal
+                      &lt;/label&gt;
+                    &lt;/th&gt;
+                  #end
+                &lt;/tr&gt;
+              &lt;/thead&gt;
+            #end
+            ## Users and their votes.
+            &lt;tbody&gt;
+              #set ($foundUser = false)
+              #set ($foundGuestUser = false)
+              #foreach ($voteObj in $doc.getObjects('XPoll.XPollVoteClass'))
+                #set ($user = $voteObj.user)
+                #set ($guestId = $voteObj.getValue('guestId'))
+                #set ($isVoteFromGuest = "$guestId" != "")
+                #set ($isVoteFromCurrentGuest = $cookieId.equals($guestId) &amp;&amp; $isCurrentContextUserGuest)
+                #set ($isCurrentUser = $user.equals($xcontext.user) &amp;&amp; !$isVoteFromGuest)
+                #set ($votes = $voteObj.getValue('votes'))
+                #set ($guestName = $voteObj.getValue('user'))
+                #set ($escapedGuestName = $escapetool.xml($guestName))
+                #if ($isCurrentUser)
+                  #set ($foundUser = true)
                 #end
-              &lt;/tr&gt;
-            &lt;/thead&gt;
-          #end
-          ## Users and their votes.
-          &lt;tbody&gt;
-            #set ($foundUser = false)
-            #set ($foundGuestUser = false)
-            #foreach ($voteObj in $doc.getObjects('XPoll.XPollVoteClass'))
-              #set ($user = $voteObj.user)
-              #set ($guestId = $voteObj.getValue('guestId'))
-              #set ($isVoteFromGuest = "$guestId" != "")
-              #set ($isVoteFromCurrentGuest = $cookieId.equals($guestId) &amp;&amp; $isCurrentContextUserGuest)
-              #set ($isCurrentUser = $user.equals($xcontext.user) &amp;&amp; !$isVoteFromGuest)
-              #set ($votes = $voteObj.getValue('votes'))
-              #set ($guestName = $voteObj.getValue('user'))
-              #set ($escapedGuestName = $escapetool.xml($guestName))
-              #if ($isCurrentUser)
-                #set ($foundUser = true)
+                #if ($isVoteFromCurrentGuest)
+                  #set ($foundGuestUser = true)
+                #end
+                ## Display the input for a guest user that already voted
+                #if ($isVoteFromCurrentGuest)
+                  &lt;tr class="active"&gt;
+                    &lt;td&gt;
+                      &lt;input type="text" value="$escapedGuestName" name="guestName" #if(!$isPollPublicityPublic) disabled#end&gt;
+                    &lt;/td&gt;
+                    #displayInput($votes $isPollPublicityPublic $guestName $foreach.index)
+                  &lt;/tr&gt;
+                #end
+                #if ($displayAllUsers)
+                  ## display the vote for a guest user that is not the current user
+                  #if ($isVoteFromGuest &amp;&amp; !$isVoteFromCurrentGuest)
+                    &lt;tr&gt;
+                      &lt;td&gt;
+                        $escapedGuestName
+                      &lt;/td&gt;
+                      #displayInput($votes false $guestName $foreach.index)
+                    &lt;/tr&gt;
+                  ## display the vote for users who are logged in or have voted while logged in
+                  #elseif ($xwiki.exists($user) &amp;&amp; !$isVoteFromGuest)
+                    &lt;tr #if ($isCurrentUser) class="active" #end&gt;
+                      &lt;td&gt;
+                        #displayUser($user, {'wrapAvatar': true})
+                      &lt;/td&gt;
+                      #displayInput($votes $isCurrentUser $user $foreach.index)
+                    &lt;/tr&gt;
+                  #end
+                #else
+                  &lt;tr class="active"&gt;
+                    #if ($isCurrentUser)
+                      &lt;td&gt;
+                        #displayUser($user, {'wrapAvatar': true})
+                      &lt;/td&gt;
+                      #displayInput($votes $isCurrentUser $user 0)
+                    #end
+                  &lt;/tr&gt;
+                #end
               #end
-              #if ($isVoteFromCurrentGuest)
-                #set ($foundGuestUser = true)
-              #end
-              ## Display the input for a guest user that already voted
-              #if ($isVoteFromCurrentGuest)
+
+              ## Display the current user if he hasn't voted yet.
+              #if (!$foundUser &amp;&amp; !$isCurrentContextUserGuest)
                 &lt;tr class="active"&gt;
                   &lt;td&gt;
-                    &lt;input type="text" value="$escapedGuestName" name="guestName" #if(!$isPollPublicityPublic) disabled#end&gt;
+                    #displayUser($xcontext.user, {'wrapAvatar': true})
                   &lt;/td&gt;
-                  #displayInput($votes $isPollPublicityPublic $guestName $foreach.index)
+                  ## The 3rd parameter is true in order to not disable the input for current user.
+                  #displayInput([] true $xcontext.user)
                 &lt;/tr&gt;
               #end
-              #if ($displayAllUsers)
-                ## display the vote for a guest user that is not the current user
-                #if ($isVoteFromGuest &amp;&amp; !$isVoteFromCurrentGuest)
-                  &lt;tr&gt;
-                    &lt;td&gt;
-                      $escapedGuestName
-                    &lt;/td&gt;
-                    #displayInput($votes false $guestName $foreach.index)
-                  &lt;/tr&gt;
-                ## display the vote for users who are logged in or have voted while logged in
-                #elseif ($xwiki.exists($user) &amp;&amp; !$isVoteFromGuest)
-                  &lt;tr #if ($isCurrentUser) class="active" #end&gt;
-                    &lt;td&gt;
-                      #displayUser($user, {'wrapAvatar': true})
-                    &lt;/td&gt;
-                    #displayInput($votes $isCurrentUser $user $foreach.index)
-                  &lt;/tr&gt;
-                #end
-              #else
+              #if (!$foundGuestUser &amp;&amp; $isCurrentContextUserGuest &amp;&amp; $isPollPublicityPublic)
                 &lt;tr class="active"&gt;
-                  #if ($isCurrentUser)
-                    &lt;td&gt;
-                      #displayUser($user, {'wrapAvatar': true})
-                    &lt;/td&gt;
-                    #displayInput($votes $isCurrentUser $user 0)
+                  &lt;td&gt;
+                    &lt;input type="text" name="guestName" value="" placeholder="Name..."&gt;
+                    #displayInput([] true $xcontext.user)
+                  &lt;/td&gt;
+                &lt;/tr&gt;
+              #end
+            &lt;/tbody&gt;
+            #if ($displayAllUsers &amp;&amp; $showPollSummary)
+              &lt;tfoot&gt;
+                &lt;tr&gt;
+                  &lt;td&gt;
+                    $escapetool.xml($services.localization.render('contrib.xpoll.numberVotes'))
+                    &lt;span class='count'&gt;($totalVotesCount)&lt;/span&gt;
+                  &lt;/td&gt;
+                  #foreach ($proposal in $proposals)
+                    &lt;td&gt; $!voteCount.get($proposal) &lt;/td&gt;
                   #end
                 &lt;/tr&gt;
-              #end
+              &lt;/tfoot&gt;
             #end
-
-            ## Display the current user if he hasn't voted yet.
-            #if (!$foundUser &amp;&amp; !$isCurrentContextUserGuest)
-              &lt;tr class="active"&gt;
-                &lt;td&gt;
-                  #displayUser($xcontext.user, {'wrapAvatar': true})
-                &lt;/td&gt;
-                ## The 3rd parameter is true in order to not disable the input for current user.
-                #displayInput([] true $xcontext.user)
-              &lt;/tr&gt;
-            #end
-            #if (!$foundGuestUser &amp;&amp; $isCurrentContextUserGuest &amp;&amp; $isPollPublicityPublic)
-              &lt;tr class="active"&gt;
-                &lt;td&gt;
-                  &lt;input type="text" name="guestName" value="" placeholder="Name..."&gt;
-                  #displayInput([] true $xcontext.user)
-                &lt;/td&gt;
-              &lt;/tr&gt;
-            #end
-          &lt;/tbody&gt;
-          #if ($displayAllUsers &amp;&amp; $showPollSummary)
-            &lt;tfoot&gt;
-              &lt;tr&gt;
-                &lt;td&gt;
-                  $escapetool.xml($services.localization.render('contrib.xpoll.numberVotes'))
-                  &lt;span class='count'&gt;($totalVotesCount)&lt;/span&gt;
-                &lt;/td&gt;
-                #foreach ($proposal in $proposals)
-                  &lt;td&gt; $!voteCount.get($proposal) &lt;/td&gt;
-                #end
-              &lt;/tr&gt;
-            &lt;/tfoot&gt;
-          #end
-        &lt;/table&gt;
-      &lt;/div&gt;
-      #if (!$isCurrentContextUserGuest || $isPollPublicityPublic)
-        &lt;div class='save'&gt;
-          &lt;input type="submit" value="$escapetool.xml($services.localization.render("contrib.xpoll.vote.user.submit"))"
-            class="button"/&gt;
+          &lt;/table&gt;
         &lt;/div&gt;
-      #end
-    &lt;/form&gt;
+        #if (!$isCurrentContextUserGuest || $isPollPublicityPublic)
+          &lt;div class='save'&gt;
+            &lt;input type="submit" value="$escapetool.xml($services.localization.render("contrib.xpoll.vote.user.submit"))"
+              class="button"/&gt;
+          &lt;/div&gt;
+        #end
+      &lt;/form&gt;
+    #end
     {{/html}}
   #elseif ($status == 'finished')
     #if(!$totalVotesCount)
@@ -464,96 +463,95 @@
     #end
     #set ($showPollSummary = !$isCurrentContextUserGuest || $currentGuestUserVoted || $userCanVote || ($displayAllUsers &amp;&amp; $usersCount &gt; 0))
     {{html wiki='true' clean='false'}}
-    #if ($showPollSummary)
-      $doc.display('description')
-      $escapetool.xml($services.localization.render('contrib.xpoll.finish.message'))
-    #end
     #if (!$showPollSummary)
       {{warning}}
       $escapetool.xml($services.localization.render('contrib.xpoll.emptyPage'))
       {{/warning}}
-    #end
-    &lt;div id="xpollTableWrapper"&gt;
-      &lt;table class='xpoll medium-avatars table table-bordered'&gt;
-        ## Table header row.
-        #if ($showPollSummary)
-          &lt;tr&gt;
-            &lt;th&gt;
-              #if($displayAllUsers)
-                #if($usersCountActive == 1)
+    #else
+      $doc.display('description')
+      $escapetool.xml($services.localization.render('contrib.xpoll.finish.message'))
+      &lt;div id="xpollTableWrapper"&gt;
+        &lt;table class='xpoll medium-avatars table table-bordered'&gt;
+          ## Table header row.
+          #if ($showPollSummary)
+            &lt;tr&gt;
+              &lt;th&gt;
+                #if($displayAllUsers)
+                  #if($usersCount == 1)
+                    $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
+                  #else
+                    $escapetool.xml($services.localization.render('contrib.xpoll.user'))
+                    &lt;span class='count'&gt;($usersCount)&lt;/span&gt;
+                  #end
+                #elseif ($currentGuestUserVoted || $currentUserVoted)
                   $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
                 #else
                   $escapetool.xml($services.localization.render('contrib.xpoll.user'))
-                  &lt;span class='count'&gt;($usersCount)&lt;/span&gt;
+                  &lt;span class='count'&gt;(0)&lt;/span&gt;
                 #end
-              #elseif ($currentGuestUserVoted || $currentUserVoted)
-                $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
-              #else
-                $escapetool.xml($services.localization.render('contrib.xpoll.user'))
-                &lt;span class='count'&gt;(0)&lt;/span&gt;
-              #end
-            &lt;/th&gt;
-            #foreach ($proposal in $proposals)
-              &lt;th&gt; $proposal &lt;/th&gt;
-            #end
-          &lt;/tr&gt;
-        #end
-        ## Users and their votes.
-        #foreach ($voteObj in $doc.getObjects('XPoll.XPollVoteClass'))
-          #set ($user = $voteObj.user)
-          #set ($votes = $voteObj.getValue('votes'))
-          #set ($guestName = $voteObj.getValue('user'))
-          #set ($escapedGuestName = $escapetool.xml($guestName))
-          #set ($guestId = $voteObj.getValue('guestId'))
-          #set ($isVoteFromGuest = "$guestId" != "")
-          #set ($isVoteFromCurrentGuest = $cookieId.equals($guestId) &amp;&amp; $isCurrentContextUserGuest)
-          #set ($isCurrentUser = $user == $xcontext.user &amp;&amp; !$isVoteFromGuest)
-          #if($displayAllUsers)
-            &lt;tr #if($isCurrentUser || $isVoteFromCurrentGuest)class="active"#end&gt;
-              #if ($isVoteFromGuest)
-                &lt;td&gt;
-                 $escapedGuestName
-                &lt;/td&gt;
-                ## The 3rd parameter is false in order to disable the input when the poll is finished.
-                #displayInput($votes false $guestName $foreach.index)
-              #else
-                &lt;td&gt;
-                  #displayUser($user, {'wrapAvatar': true})
-                &lt;/td&gt;
-                ## The 3rd parameter is false in order to disable the input when the poll is finished.
-                #displayInput($votes false $user $foreach.index)
-              #end
-            &lt;/tr&gt;
-          #else
-            &lt;tr class="active"&gt;
-              #if ($isVoteFromCurrentGuest)
-                &lt;td&gt;
-                  $escapedGuestName
-                &lt;/td&gt;
-                #displayInput($votes false $guestName 0)
-              #elseif ($isCurrentUser)
-                &lt;td&gt;
-                  #displayUser($user, {'wrapAvatar': true})
-                &lt;/td&gt;
-                ## The 3rd parameter is false in order to disable the input when the poll is finished.
-                #displayInput($votes false $user 0)
+              &lt;/th&gt;
+              #foreach ($proposal in $proposals)
+                &lt;th&gt; $proposal &lt;/th&gt;
               #end
             &lt;/tr&gt;
           #end
-        #end
-        #if ($showPollSummary)
-          &lt;tr&gt;
-            &lt;td&gt;
-              $escapetool.xml($services.localization.render('contrib.xpoll.numberVotes'))
-              &lt;span class='count'&gt;($totalVotesCount)&lt;/span&gt;
-            &lt;/td&gt;
-            #foreach ($proposal in $proposals)
-              &lt;td&gt; $!voteCount.get($proposal) &lt;/td&gt;
+          ## Users and their votes.
+          #foreach ($voteObj in $doc.getObjects('XPoll.XPollVoteClass'))
+            #set ($user = $voteObj.user)
+            #set ($votes = $voteObj.getValue('votes'))
+            #set ($guestName = $voteObj.getValue('user'))
+            #set ($escapedGuestName = $escapetool.xml($guestName))
+            #set ($guestId = $voteObj.getValue('guestId'))
+            #set ($isVoteFromGuest = "$guestId" != "")
+            #set ($isVoteFromCurrentGuest = $cookieId.equals($guestId) &amp;&amp; $isCurrentContextUserGuest)
+            #set ($isCurrentUser = $user == $xcontext.user &amp;&amp; !$isVoteFromGuest)
+            #if($displayAllUsers)
+              &lt;tr #if($isCurrentUser || $isVoteFromCurrentGuest)class="active"#end&gt;
+                #if ($isVoteFromGuest)
+                  &lt;td&gt;
+                   $escapedGuestName
+                  &lt;/td&gt;
+                  ## The 3rd parameter is false in order to disable the input when the poll is finished.
+                  #displayInput($votes false $guestName $foreach.index)
+                #else
+                  &lt;td&gt;
+                    #displayUser($user, {'wrapAvatar': true})
+                  &lt;/td&gt;
+                  ## The 3rd parameter is false in order to disable the input when the poll is finished.
+                  #displayInput($votes false $user $foreach.index)
+                #end
+              &lt;/tr&gt;
+            #else
+              &lt;tr class="active"&gt;
+                #if ($isVoteFromCurrentGuest)
+                  &lt;td&gt;
+                    $escapedGuestName
+                  &lt;/td&gt;
+                  #displayInput($votes false $guestName 0)
+                #elseif ($isCurrentUser)
+                  &lt;td&gt;
+                    #displayUser($user, {'wrapAvatar': true})
+                  &lt;/td&gt;
+                  ## The 3rd parameter is false in order to disable the input when the poll is finished.
+                  #displayInput($votes false $user 0)
+                #end
+              &lt;/tr&gt;
             #end
-          &lt;/tr&gt;
-        #end
-      &lt;/table&gt;
-    &lt;/div&gt;
+          #end
+          #if ($showPollSummary)
+            &lt;tr&gt;
+              &lt;td&gt;
+                $escapetool.xml($services.localization.render('contrib.xpoll.numberVotes'))
+                &lt;span class='count'&gt;($totalVotesCount)&lt;/span&gt;
+              &lt;/td&gt;
+              #foreach ($proposal in $proposals)
+                &lt;td&gt; $!voteCount.get($proposal) &lt;/td&gt;
+              #end
+            &lt;/tr&gt;
+          #end
+        &lt;/table&gt;
+      &lt;/div&gt;
+    #end
     {{/html}}
   #end
 #end

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
@@ -345,7 +345,7 @@
                   #foreach($proposal in $proposals)
                     &lt;th&gt;
                       &lt;label for="xpoll-proposal$proposal.hashCode()"&gt;
-                        $proposal
+                        $escapetool.xml($proposal)
                       &lt;/label&gt;
                     &lt;/th&gt;
                   #end
@@ -491,7 +491,7 @@
                 #end
               &lt;/th&gt;
               #foreach ($proposal in $proposals)
-                &lt;th&gt; $proposal &lt;/th&gt;
+                &lt;th&gt; $escapetool.xml($proposal) &lt;/th&gt;
               #end
             &lt;/tr&gt;
           #end

--- a/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
+++ b/application-xpoll-ui/src/main/resources/XPoll/XPollSheet.xml
@@ -85,9 +85,9 @@
             #end
 
             #if ($disabled.isEmpty())
-              &lt;select class="xpollSelect" data-proposal="$escapetool.xml($proposal)"&gt;
+              &lt;select class="xpollSelect" data-proposal="$services.rendering.escape($escapetool.xml($proposal), 'xwiki/2.1')"&gt;
                 &lt;option disabled $noOption value=""&gt;
-                  $escapetool.xml($services.localization.render('contrib.xpoll.vote.select'))
+                  $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.vote.select')), 'xwiki/2.1')
                 &lt;/option&gt;
                 #foreach ($index in [1..$proposals.size()])
                   &lt;option value="$index" #if($index == $indexOfProposal)selected#end&gt;
@@ -97,7 +97,7 @@
               &lt;/select&gt;
               ## The hidden inputs that will have the values sent by the form.
               &lt;input class="xpollHiddenInput" id="option$foreach.count" name="proposals"
-               #if ($votes.size() &gt; $foreach.index)value="$escapetool.xml($votes.get($foreach.index))"#end
+               #if ($votes.size() &gt; $foreach.index)value="$services.localization.render($escapetool.xml($votes.get($foreach.index)), 'xwiki/2.1')"#end
                 type="hidden"/&gt;
             #else
               &lt;input type="checkbox" $checked $disabled /&gt;
@@ -109,7 +109,7 @@
           #else
             &lt;input type="#if($isRadio)radio#{else}checkbox#end"
               #if($isCurrentUser)id="xpoll-proposal$proposal.hashCode()"#end name="${inputName}"
-              value="$escapetool.xml($proposal)" $checked
+              value="$services.localization.render($escapetool.xml($proposal), 'xwiki/2.1')" $checked
               $disabled /&gt;
           #end
         &lt;/label&gt;
@@ -311,13 +311,13 @@
     {{html clean='false', wiki='true'}}
     #if (!($showPollSummary || $displayAllUsers))
       {{warning}}
-      $escapetool.xml($services.localization.render('contrib.xpoll.emptyPage'))
+      $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.emptyPage')), 'xwiki/2.1')
       {{/warning}}
     #else
       $doc.display('description')
       #if (!$isPollPublicityPublic &amp;&amp; $currentGuestUserVoted)
         {{warning}}
-        $escapetool.xml($services.localization.render('contrib.xpoll.guestCannotChangeVote'))
+        $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.guestCannotChangeVote')), 'xwiki/2.1')
         {{/warning}}
       #end
       &lt;form id="xpollSaveForm" action="$restURL" method="put"&gt;
@@ -330,22 +330,22 @@
                   &lt;th&gt;
                     #if($displayAllUsers)
                       #if($usersCountActive == 1)
-                        $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
+                        $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.singleUser')), 'xwiki/2.1')
                       #else
-                        $escapetool.xml($services.localization.render('contrib.xpoll.user'))
+                        $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.user')), 'xwiki/2.1')
                         &lt;span class='count'&gt;($usersCountActive)&lt;/span&gt;
                       #end
                     #elseif ($currentGuestUserVoted || $currentUserVoted)
-                      $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
+                      $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.singleUser')), 'xwiki/2.1')
                     #else
-                      $escapetool.xml($services.localization.render('contrib.xpoll.user'))
+                      $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.user')), 'xwiki/2.1')
                       &lt;span class='count'&gt;(0)&lt;/span&gt;
                     #end
                   &lt;/th&gt;
                   #foreach($proposal in $proposals)
                     &lt;th&gt;
                       &lt;label for="xpoll-proposal$proposal.hashCode()"&gt;
-                        $escapetool.xml($proposal)
+                        $services.rendering.escape($escapetool.xml($proposal), 'xwiki/2.1')
                       &lt;/label&gt;
                     &lt;/th&gt;
                   #end
@@ -364,7 +364,7 @@
                 #set ($isCurrentUser = $user.equals($xcontext.user) &amp;&amp; !$isVoteFromGuest)
                 #set ($votes = $voteObj.getValue('votes'))
                 #set ($guestName = $voteObj.getValue('user'))
-                #set ($escapedGuestName = $escapetool.xml($guestName))
+                #set ($escapedGuestName = $services.rendering.escape($escapetool.xml($guestName), 'xwiki/2.1'))
                 #if ($isCurrentUser)
                   #set ($foundUser = true)
                 #end
@@ -433,7 +433,7 @@
               &lt;tfoot&gt;
                 &lt;tr&gt;
                   &lt;td&gt;
-                    $escapetool.xml($services.localization.render('contrib.xpoll.numberVotes'))
+                    $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.numberVotes')), 'xwiki/2.1')
                     &lt;span class='count'&gt;($totalVotesCount)&lt;/span&gt;
                   &lt;/td&gt;
                   #foreach ($proposal in $proposals)
@@ -446,7 +446,7 @@
         &lt;/div&gt;
         #if (!$isCurrentContextUserGuest || $isPollPublicityPublic)
           &lt;div class='save'&gt;
-            &lt;input type="submit" value="$escapetool.xml($services.localization.render("contrib.xpoll.vote.user.submit"))"
+            &lt;input type="submit" value="$services.rendering.escape($escapetool.xml($services.localization.render("contrib.xpoll.vote.user.submit")), 'xwiki/2.1')"
               class="button"/&gt;
           &lt;/div&gt;
         #end
@@ -465,11 +465,11 @@
     {{html wiki='true' clean='false'}}
     #if (!$showPollSummary)
       {{warning}}
-      $escapetool.xml($services.localization.render('contrib.xpoll.emptyPage'))
+      $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.emptyPage')), 'xwiki/2.1')
       {{/warning}}
     #else
       $doc.display('description')
-      $escapetool.xml($services.localization.render('contrib.xpoll.finish.message'))
+      $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.finish.message')), 'xwiki/2.1')
       &lt;div id="xpollTableWrapper"&gt;
         &lt;table class='xpoll medium-avatars table table-bordered'&gt;
           ## Table header row.
@@ -478,20 +478,20 @@
               &lt;th&gt;
                 #if($displayAllUsers)
                   #if($usersCount == 1)
-                    $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
+                    $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.singleUser')), 'xwiki/2.1')
                   #else
-                    $escapetool.xml($services.localization.render('contrib.xpoll.user'))
+                    $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.user')), 'xwiki/2.1')
                     &lt;span class='count'&gt;($usersCount)&lt;/span&gt;
                   #end
                 #elseif ($currentGuestUserVoted || $currentUserVoted)
-                  $escapetool.xml($services.localization.render('contrib.xpoll.singleUser'))
+                  $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.singleUser')), 'xwiki/2.1')
                 #else
-                  $escapetool.xml($services.localization.render('contrib.xpoll.user'))
+                  $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.user')), 'xwiki/2.1')
                   &lt;span class='count'&gt;(0)&lt;/span&gt;
                 #end
               &lt;/th&gt;
               #foreach ($proposal in $proposals)
-                &lt;th&gt; $escapetool.xml($proposal) &lt;/th&gt;
+                &lt;th&gt; $services.rendering.escape($escapetool.xml($proposal), 'xwiki/2.1') &lt;/th&gt;
               #end
             &lt;/tr&gt;
           #end
@@ -500,7 +500,7 @@
             #set ($user = $voteObj.user)
             #set ($votes = $voteObj.getValue('votes'))
             #set ($guestName = $voteObj.getValue('user'))
-            #set ($escapedGuestName = $escapetool.xml($guestName))
+            #set ($escapedGuestName = $services.rendering.escape($escapetool.xml($guestName), 'xwiki/2.1'))
             #set ($guestId = $voteObj.getValue('guestId'))
             #set ($isVoteFromGuest = "$guestId" != "")
             #set ($isVoteFromCurrentGuest = $cookieId.equals($guestId) &amp;&amp; $isCurrentContextUserGuest)
@@ -541,7 +541,7 @@
           #if ($showPollSummary)
             &lt;tr&gt;
               &lt;td&gt;
-                $escapetool.xml($services.localization.render('contrib.xpoll.numberVotes'))
+                $services.rendering.escape($escapetool.xml($services.localization.render('contrib.xpoll.numberVotes')), 'xwiki/2.1')
                 &lt;span class='count'&gt;($totalVotesCount)&lt;/span&gt;
               &lt;/td&gt;
               #foreach ($proposal in $proposals)


### PR DESCRIPTION
In this PR, the tests were fixed and some new ones were added to verify what guest users can and cannot see. Additionally, for guest users who have edit rights, voting was allowed since they could grant themselves the right to vote (by setting the poll publicity to public). The generation of a form without inputs was removed in cases where there are no votes or the user is not allowed to vote.